### PR TITLE
Fix warning INJECT_FACTS_AS_VARS

### DIFF
--- a/roles/systemd_timesyncd/vars/main.yml
+++ b/roles/systemd_timesyncd/vars/main.yml
@@ -5,16 +5,16 @@
 # -----------------------------------------------------------------------------
 
 __systemd_timesyncd_distro: >-
-  {{ ansible_distribution | lower }}
+  {{ ansible_facts["distribution"] | lower }}
 
 __systemd_timesyncd_os: >-
-  {{ ansible_os_family | lower }}
+  {{ ansible_facts["os_family"] | lower }}
 
 __systemd_timesyncd_distro_version: >-
-  {{ __systemd_timesyncd_distro }}_{{ ansible_distribution_major_version }}
+  {{ __systemd_timesyncd_distro }}_{{ ansible_facts["distribution_major_version"] }}
 
 __systemd_timesyncd_os_version: >-
-  {{ __systemd_timesyncd_os }}_{{ ansible_distribution_major_version }}
+  {{ __systemd_timesyncd_os }}_{{ ansible_facts["distribution_major_version"] }}
 
 # -----------------------------------------------------------------------------
 # first found snippets


### PR DESCRIPTION
Good afternoon.
I encountered a warning when using a role:
```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /home/user/.ansible/roles/idiv_biodiversity.systemd_timesyncd/vars/main.yml:7:29

5 # -----------------------------------------------------------------------------
6
7 __systemd_timesyncd_distro: >-
                              ^ column 29

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```

This is a fix for that.